### PR TITLE
fix panic of grpcinvoke

### DIFF
--- a/service/grpcinvoke/invokeimpl/grpc_client.go
+++ b/service/grpcinvoke/invokeimpl/grpc_client.go
@@ -42,17 +42,30 @@ func newErrorGrpcClient(err error) *grpcClient {
 }
 
 func (client *grpcClient) Header(reqHeader proto.Message) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
 	client.header = reqHeader
 	return client
 }
 
 func (client *grpcClient) ReqService(reqService string) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
 	client.reqService = reqService
-
 	return client
 }
 
 func (client *grpcClient) Body(reqBody proto.Message) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
+
+	if reqBody == nil {
+		return client
+	}
+
 	client.body = reqBody
 
 	if client.callName == "" {
@@ -64,6 +77,9 @@ func (client *grpcClient) Body(reqBody proto.Message) grpcinvoke.Client {
 }
 
 func (client *grpcClient) Fallback(f func(error) error) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
 	client.fallback = f
 	return client
 }
@@ -169,6 +185,9 @@ func (client *grpcClient) catchAndReturnError(originErr error) error {
 }
 
 func (client *grpcClient) Context(ctx context.Context) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
 	client.ctx = ctx
 	return client
 }
@@ -272,12 +291,20 @@ func (client *grpcClient) updateHystrix() {
 
 // UseCircuit 启用熔断
 func (client *grpcClient) UseCircuit(enable bool) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
+
 	client.useCircuit = enable
 	return client
 }
 
 // MaxConcurrent 最大并发请求
 func (client *grpcClient) MaxConcurrent(maxConn int) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
+
 	if maxConn < 30 {
 		maxConn = 30
 	} else if maxConn > 10000 {
@@ -289,6 +316,10 @@ func (client *grpcClient) MaxConcurrent(maxConn int) grpcinvoke.Client {
 
 // Timeout 请求超时立即返回时间
 func (client *grpcClient) Timeout(timeout time.Duration) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
+
 	if timeout < 10*time.Millisecond {
 		timeout = time.Millisecond * 10
 	} else if timeout > 10000*time.Millisecond {
@@ -302,6 +333,10 @@ func (client *grpcClient) Timeout(timeout time.Duration) grpcinvoke.Client {
 
 // PercentThreshold 最大错误容限
 func (client *grpcClient) PercentThreshold(thresholdPercent int) grpcinvoke.Client {
+	if client.err != nil {
+		return client
+	}
+
 	if thresholdPercent < 5 {
 		thresholdPercent = 5
 	} else if thresholdPercent > 100 {

--- a/service/grpcinvoke/invokeimpl/grpc_util.go
+++ b/service/grpcinvoke/invokeimpl/grpc_util.go
@@ -147,8 +147,9 @@ func dialGrpcConnByDiscovery(target string, discovery grpcinvoke.DiscoveryFunc) 
 		target,
 		grpc.WithInsecure(),
 		grpc.WithBalancer(balancer),
-		grpc.WithBlock(),
+		// grpc.WithBlock(),
 	)
+	time.Sleep(time.Millisecond * 200)
 	if err != nil {
 		return nil, err
 	}

--- a/service/grpcinvoke/invokeimpl/grpc_util_test.go
+++ b/service/grpcinvoke/invokeimpl/grpc_util_test.go
@@ -57,7 +57,7 @@ func TestDialGrpcConnByDiscovery(t *testing.T) {
 					return []string{}, []string{}, nil
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 
 		{

--- a/service/grpcsrv/hooks.go
+++ b/service/grpcsrv/hooks.go
@@ -45,7 +45,7 @@ func HookRecovery(f HandlerFunc) HandlerFunc {
 					}
 					// 此类错误一般由服务内部参数，返回了一个数字类型的错误码
 					commRsp = newErrorRsp(
-						fmt.Sprintf("%s%d", mcodePrefix, cerr.Code()),
+						fmt.Sprintf("%s_%d", mcodePrefix, cerr.Code()),
 						cerr.Error())
 
 					return

--- a/service/grpcsrv/hooks_test.go
+++ b/service/grpcsrv/hooks_test.go
@@ -15,7 +15,7 @@ func TestHookRecover(t *testing.T) {
 		f HandlerFunc
 	}
 
-	mcodePrefix = "ERROR_"
+	mcodePrefix = "ERROR"
 	tests := []struct {
 		name      string
 		args      args

--- a/service/grpcsrv/report/monitor_reporter.go
+++ b/service/grpcsrv/report/monitor_reporter.go
@@ -27,7 +27,7 @@ func (reporter *MonitorReporter) Report(reqInterface, reqService, fromHost strin
 	}()
 
 	isSucc := result == ""
-	infc := fmt.Sprintf("ACTIVE_GRPC_%s", reqInterface)
+	infc := fmt.Sprintf("PASSIVE_GRPC_%s", reqInterface)
 	localIp := monitor.GetCurrentServerIP()
 	delayMs := int64(delay / time.Millisecond)
 	if isSucc {

--- a/service/grpcsrv/util.go
+++ b/service/grpcsrv/util.go
@@ -24,7 +24,7 @@ func newErrorRsp(mcode string, format string, args ...interface{}) *grpccomm.Com
 	return &grpccomm.CommResponse{
 		Result:  false,
 		Mcode:   mcode,
-		Message: fmt.Sprintf("grpcsrv:"+format, args...),
+		Message: fmt.Sprintf(format, args...),
 	}
 }
 

--- a/service/grpcsrv/util.go
+++ b/service/grpcsrv/util.go
@@ -47,7 +47,7 @@ func newRspFromError(err error) *grpccomm.CommResponse {
 
 var (
 	// CerrCheckSnowProtect 雪崩预警
-	CerrCheckSnowProtect = code.New(10011, "Check Snow Protect")
+	CerrCheckSnowProtect = code.NewMcode("SNOWSLIDE_DENIED", "Check Snow Protect")
 	gCurTime             int64
 	checkSnowMutex       sync.Mutex
 	gCurCount            int32


### PR DESCRIPTION
修复Panic，让grpcinvoke.Client 传参时，如果之前发生过错误，则快速返回失败；
修复grpcsrv，返回错误码的时候，前缀后面缺失一个下划线；
更新grpcsrv，返回错误的时候，Message总是带有`grpcsrv:`是多余的，因此拿掉。